### PR TITLE
Fix support_info_by_support_statement JS for empty statement

### DIFF
--- a/support_info_by_support_statement.xslt
+++ b/support_info_by_support_statement.xslt
@@ -76,6 +76,9 @@ xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
     };
     for (const [s_id, start_date] of Object.entries(support_dates)) {
       rows = document.getElementById(s_id).getElementsByTagName("tr")
+      if (rows.length &lt; 2) {
+            continue; // Maybe no packages
+      }
       newclass = rows[1].getAttribute("class");
 
       sd = new Date(start_date);


### PR DESCRIPTION
Otherwise we hit an error as rows[1] refers to a row that doesn't exist.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
